### PR TITLE
Add tests to mujoco_compile utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mujoco_cmake VERSION 2.1.0)
 
 set(MJ_VER ${PROJECT_VERSION_MAJOR}${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH})
 
-
+include(CTest)
 include(ExternalProject)
 
 ExternalProject_Add(
@@ -55,3 +55,19 @@ install(
     DESTINATION
     bin
     )
+
+
+add_custom_command(
+    TARGET mujoco
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} ..
+  )
+
+file(GLOB xml_models "${CMAKE_CURRENT_BINARY_DIR}/mujoco/src/mujoco/model/*/*.xml")
+
+foreach(model ${xml_models})
+  add_test(
+    NAME "mujoco_compile_test_${model}"
+    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=./mujoco/src/mujoco/lib/;$ENV{LD_LIBRARY_PATH}"
+    sh -c "./mujoco_compile ${model}")
+endforeach()    


### PR DESCRIPTION
The idea is simple: it happens sometimes that there is a mismatch between the meta-model and xml models, which later causes compile time fails. This PR will run the compile command against all xml models that are shipped with the packaged mujoco.

To use, simply run `make test` after `make`.

Note that since the actual download phase of the `ExternalProject_Add` does not happen until the build stage (`make` or `cmake --build .`), but the tests need those files at configuration time at the configuration stage, I added a `POST_BUILD` step which simply reruns the cmake after a successfully `make`. I am not proud of it but it works.